### PR TITLE
Fix footer links

### DIFF
--- a/src/components/FooterBar.jsx
+++ b/src/components/FooterBar.jsx
@@ -18,13 +18,13 @@ export const FooterBar = () => {
             <p className="pt-sm-0">Presidenza del Consiglio dei Ministri</p>
           </div>
           <div className="col-md-4 d-flex justify-content-md-center justify-content-sm-start logo-section pt-2 pb-2">
-            <a href="http://www.governo.it" className="text-decoration-none" target="_blank" rel="noreferrer">
+            <a href="http://www.governo.it/it/dipartimenti/commissario-straordinario-lemergenza-covid-19/15974" className="text-decoration-none" target="_blank" rel="noreferrer">
               <img src="logo.svg" height="4px" alt="Logo" className="logo pl-5 pr-2" />
             </a>
             <p className="pt-sm-0">Commissario Straordinario Covid-19</p>
           </div>
           <div className="col-md-4 d-flex justify-content-md-center justify-content-sm-start logo-section pt-2 pb-2">
-            <a href="http://www.governo.it" className="text-decoration-none" target="_blank" rel="noreferrer">
+            <a href="http://www.salute.gov.it/portale/home.html" className="text-decoration-none" target="_blank" rel="noreferrer">
               <img src="logo.svg" height="4px" alt="Logo" className="logo pl-5 pr-2" />
             </a>
             <p className="pt-sm-0">Ministero della Salute</p>


### PR DESCRIPTION
I link nel footer dirigevano genericamente a governo.it mentre nell'header gli stessi link dirigono alle rispettive pagine.

Questa PR fixa soltanto i link.

Il footer comunque presenta altri problemi, tra cui il fatto che i link sono solo sui simboli e non sul testo, è voluto o c'è bisogno di sistemarlo? posso farlo sia qui che in una nuova PR. Design-wise si potrebbe pure aggiustare il footer come mirror dell'header (spacing è differente) ma anche quello non son sicuro sia voluto o meno.

Let me know if an English translation is needed.