### PR TITLE
fix: declare the language

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -10,7 +10,11 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="loader-custom" class="box-loader position-fixed" style="z-index: 10000;">
+    <div
+      id="loader-custom"
+      class="box-loader position-fixed"
+      style="z-index: 10000"
+    >
       <div class="progress-spinner progress-spinner-active">
         <!-- <span class="sr-only">Caricamento...</span> -->
       </div>


### PR DESCRIPTION
The language of this document is mistakenly declared as English when it should be Italian.

This is also resolved in #18 but since that also includes some copy and iconography which might have a different review cycle I wanted to make this specific PR on this small change.